### PR TITLE
Fix code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/base/base/conv.go
+++ b/base/base/conv.go
@@ -27,8 +27,11 @@ func StringToInt32(s string) (int32, error) {
 }
 
 func StringToUint32(s string) (uint32, error) {
-	i, err := strconv.Atoi(s)
-	return uint32(i), err
+	i, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	return uint32(i), nil
 }
 
 func StringToInt64(s string) (int64, error) {


### PR DESCRIPTION
Fixes [https://github.com/offsoc/telegramd/security/code-scanning/2](https://github.com/offsoc/telegramd/security/code-scanning/2)

To fix the problem, we need to ensure that the value parsed from the string does not exceed the bounds of `uint32` before performing the conversion. This can be achieved by using `strconv.ParseUint` with a bit size of 32, which directly parses the string into a `uint32` value, ensuring that the value is within the valid range for `uint32`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
