### PR TITLE
Fix code scanning alert no. 1: Incorrect conversion between integer types

### DIFF
--- a/base/base/conv.go
+++ b/base/base/conv.go
@@ -19,16 +19,29 @@ package base
 
 import (
 	"strconv"
+	"math"
 )
 
 func StringToInt32(s string) (int32, error) {
-	i, err := strconv.Atoi(s)
-	return int32(i), err
+	i, err := strconv.ParseInt(s, 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	if i < math.MinInt32 || i > math.MaxInt32 {
+		return 0, strconv.ErrRange
+	}
+	return int32(i), nil
 }
 
 func StringToUint32(s string) (uint32, error) {
-	i, err := strconv.Atoi(s)
-	return uint32(i), err
+	i, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	if i > math.MaxUint32 {
+		return 0, strconv.ErrRange
+	}
+	return uint32(i), nil
 }
 
 func StringToInt64(s string) (int64, error) {


### PR DESCRIPTION
Fixes [https://github.com/offsoc/telegramd/security/code-scanning/1](https://github.com/offsoc/telegramd/security/code-scanning/1)

To fix the problem, we need to ensure that the integer value parsed from the string is within the bounds of the target type (`int32` or `uint32`) before performing the conversion. This can be achieved by using `strconv.ParseInt` or `strconv.ParseUint` with the appropriate bit size and then checking the bounds.

1. For `StringToInt32`, use `strconv.ParseInt` with a bit size of 32 and check if the parsed value is within the bounds of `int32`.
2. For `StringToUint32`, use `strconv.ParseUint` with a bit size of 32 and check if the parsed value is within the bounds of `uint32`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
