### PR TITLE
Fix code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/biz_model/model/online_status_model.go
+++ b/biz_model/model/online_status_model.go
@@ -187,7 +187,7 @@ func (s *onlineStatusModel) getOnline(conn redis.Conn, userId int32) (statusList
 
 		if time.Now().Unix() < status.Now + CHECK_ONLINE_TIMEOUT {
 			statusList = append(statusList, status)
-			fmt.Println(status)
+			fmt.Printf("User %d is online.\n", status.UserId)
 		}
 	}
 	return


### PR DESCRIPTION
Fixes [https://github.com/offsoc/telegramd/security/code-scanning/4](https://github.com/offsoc/telegramd/security/code-scanning/4)

To fix the problem, we need to ensure that sensitive information is not logged in clear text. Instead of logging the entire `status` object, we should log only non-sensitive parts of it or obfuscate the sensitive information. In this case, we will log only the `UserId` and omit the rest of the `status` fields.

- Modify the logging statement on line 190 to exclude sensitive information.
- Ensure that the fix does not change the existing functionality of the code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
